### PR TITLE
Add MySQL migration example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ HOST=localhost
 PORT=3080
 
 MONGO_URI=mongodb://127.0.0.1:27017/LibreChat
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_USER=root
+MYSQL_PASSWORD=password
+MYSQL_DATABASE=librechat
 
 DOMAIN_CLIENT=http://localhost:3080
 DOMAIN_SERVER=http://localhost:3080

--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ If you'd like to help translate LibreChat into your language, we'd love your con
 
 ---
 
+## MySQL Migration Example
+
+Use `node config/migrate-to-mysql.js` to copy user data to a MySQL database. Configure connection variables `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_USER`, `MYSQL_PASSWORD` and `MYSQL_DATABASE`.
+
+---
+
 ## 🎉 Special Thanks
 
 We thank [Locize](https://locize.com) for their translation management tools that support multiple languages in LibreChat.

--- a/api/package.json
+++ b/api/package.json
@@ -86,6 +86,8 @@
     "mime": "^3.0.0",
     "module-alias": "^2.2.3",
     "mongoose": "^8.12.1",
+    "mysql2": "^3.9.2",
+    "sequelize": "^6.37.1",
     "multer": "^1.4.5-lts.1",
     "nanoid": "^3.3.7",
     "nodemailer": "^6.9.15",

--- a/config/migrate-to-mysql.js
+++ b/config/migrate-to-mysql.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+const mongoose = require('mongoose');
+const mysql = require('mysql2/promise');
+const User = require('../api/models/User');
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI);
+  const connection = await mysql.createConnection({
+    host: process.env.MYSQL_HOST,
+    port: process.env.MYSQL_PORT || 3306,
+    user: process.env.MYSQL_USER,
+    password: process.env.MYSQL_PASSWORD,
+    database: process.env.MYSQL_DATABASE,
+  });
+  await connection.execute(
+    'CREATE TABLE IF NOT EXISTS users (id VARCHAR(255) PRIMARY KEY, email VARCHAR(255), password VARCHAR(255))'
+  );
+  const users = await User.find().lean();
+  const query =
+    'INSERT INTO users (id, email, password) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE email=VALUES(email), password=VALUES(password)';
+  for (const u of users) {
+    await connection.execute(query, [u._id.toString(), u.email, u.password]);
+  }
+  await connection.end();
+  await mongoose.disconnect();
+}
+
+run();


### PR DESCRIPTION
## Summary
- add mysql2 and sequelize dependencies
- add config/migrate-to-mysql.js to copy users from MongoDB into MySQL
- document new script and variables in README
- extend `.env.example` with MySQL connection options

## Testing
- `npm run test:api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d74feb4548323a8f94304d3be61f3