### PR TITLE
Add rootless Docker install script

### DIFF
--- a/rootless_docker_install.sh
+++ b/rootless_docker_install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+command -v curl >/dev/null 2>&1
+curl -fsSL https://get.docker.com/rootless | sh
+dockerd-rootless-setuptool.sh install
+echo "export PATH=$HOME/bin:$PATH" >> ~/.profile
+echo "export DOCKER_HOST=unix:///run/user/$(id -u)/docker.sock" >> ~/.profile


### PR DESCRIPTION
## Summary
- add an install script for Docker rootless mode
- remove sudo/apt commands to suit restricted hosting

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9f028b648323811ebdd03b55e43d